### PR TITLE
Use File.exist? instead of File.exists?

### DIFF
--- a/lib/middleman-search/search-index-resource.rb
+++ b/lib/middleman-search/search-index-resource.rb
@@ -140,7 +140,7 @@ module Middleman
       def lunr_resource(resource_name)
         @lunr_dirs.flat_map do |dir|
           [File.join(dir, minified_path(resource_name)), File.join(dir, resource_name)]
-        end.detect { |file| File.exists? file } or raise "Couldn't find #{resource_name} nor #{minified_path(resource_name)} in #{@lunr_dirs.map {|dir| File.absolute_path dir }.join File::PATH_SEPARATOR}"
+        end.detect { |file| File.exist? file } or raise "Couldn't find #{resource_name} nor #{minified_path(resource_name)} in #{@lunr_dirs.map {|dir| File.absolute_path dir }.join File::PATH_SEPARATOR}"
       end
     end
   end


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2 (or https://github.com/ruby/ruby/pull/5352)

This enables users to use Ruby 3.2 or higher.

- Port of (PR for the upstream) https://github.com/manastech/middleman-search/pull/39

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)